### PR TITLE
Consent expiration setting

### DIFF
--- a/src/IdentityServer4/Models/Client.cs
+++ b/src/IdentityServer4/Models/Client.cs
@@ -166,6 +166,11 @@ namespace IdentityServer4.Models
         public int SlidingRefreshTokenLifetime { get; set; } = 1296000;
 
         /// <summary>
+        /// Lifetime of a user consent in seconds. Defaults to null (no expiration)
+        /// </summary>
+        public int? ConsentLifetime { get; set; } = null;
+
+        /// <summary>
         /// ReUse: the refresh token handle will stay the same when refreshing tokens
         /// OneTime: the refresh token handle will be updated when refreshing tokens
         /// </summary>

--- a/src/IdentityServer4/Services/DefaultConsentService.cs
+++ b/src/IdentityServer4/Services/DefaultConsentService.cs
@@ -126,6 +126,12 @@ namespace IdentityServer4.Services
                         ClientId = clientId,
                         Scopes = scopes
                     };
+
+                    if (client.ConsentLifetime.HasValue)
+                    {
+                        consent.Expiration = consent.CreationTime.AddSeconds(client.ConsentLifetime.Value);
+                    }
+
                     await _userConsentStore.StoreUserConsentAsync(consent);
                 }
                 else


### PR DESCRIPTION
Support a consent lifetime to require a resource owner to re-consent

- Add a `ConsentLifetime` property to `Client` model.
- Required pulling changes for consistent expiration handling to allow an expired consent to be returned form the `DefaultGrantStore` so that it could be checked in `DefaultConsentService.RequireConsentAsync()`
- Add unit tests to validate consent expiration
